### PR TITLE
Add media generation utilities

### DIFF
--- a/src/ai_agentic_workflow/utils/media_utils.py
+++ b/src/ai_agentic_workflow/utils/media_utils.py
@@ -1,0 +1,77 @@
+import os
+import json
+import logging
+import re
+from typing import List, Dict, Any
+
+import requests
+import openai
+import google.generativeai as genai
+
+from .env_reader import get_env_variable
+
+logger = logging.getLogger(__name__)
+
+
+def _slugify(text: str) -> str:
+    slug = re.sub(r"[^a-zA-Z0-9]+", "_", text.strip().lower())
+    return slug.strip("_")
+
+
+def generate_image(prompt: str, api_key: str, model: str = "dall-e-3") -> bytes:
+    """Generate an image using OpenAI's image API and return raw bytes."""
+    client = openai.OpenAI(api_key=api_key)
+    response = client.images.generate(prompt=prompt, n=1, model=model)
+    url = response.data[0].url
+    resp = requests.get(url, timeout=30)
+    resp.raise_for_status()
+    return resp.content
+
+
+def generate_audio(text: str, api_key: str, model: str = "gemini-2.5-pro-preview-tts") -> bytes:
+    """Generate speech audio using Gemini TTS and return raw bytes."""
+    genai.configure(api_key=api_key)
+    model_obj = genai.GenerativeModel(model)
+    response = model_obj.generate_content(text)
+    try:
+        audio_bytes = response.candidates[0].audio
+    except Exception as exc:  # pragma: no cover - depends on API
+        logger.error("Unexpected audio response: %s", exc)
+        raise
+    return audio_bytes
+
+
+def create_media_files(visual_prompts: List[Dict[str, Any]],
+                       script_scenes: List[Dict[str, Any]],
+                       output_dir: str = "media") -> None:
+    """Generate image and audio files for each scene."""
+    openai_key = get_env_variable("OPENAI_API_KEY")
+    gemini_key = get_env_variable("GEMINI_API_KEY")
+    os.makedirs(output_dir, exist_ok=True)
+
+    for prompt in visual_prompts:
+        scene_num = int(prompt.get("scene_number", 0))
+        desc = prompt.get("main_subject", "scene")
+        slug = _slugify(desc)[:40]
+        text_prompt = json.dumps(prompt)
+        try:
+            img_bytes = generate_image(text_prompt, api_key=openai_key)
+            img_path = os.path.join(output_dir, f"{scene_num:02d}_{slug}.png")
+            with open(img_path, "wb") as f:
+                f.write(img_bytes)
+            logger.info("Saved image %s", img_path)
+        except Exception as exc:  # pragma: no cover - network failures not tested
+            logger.error("Failed generating image for scene %s: %s", scene_num, exc)
+
+    for scene in script_scenes:
+        scene_num = int(scene.get("scene_number", 0))
+        narration = scene.get("narration", "")
+        slug = _slugify(scene.get("title", "scene"))[:40]
+        try:
+            audio_bytes = generate_audio(narration, api_key=gemini_key)
+            audio_path = os.path.join(output_dir, f"{scene_num:02d}_{slug}.mp3")
+            with open(audio_path, "wb") as f:
+                f.write(audio_bytes)
+            logger.info("Saved audio %s", audio_path)
+        except Exception as exc:  # pragma: no cover
+            logger.error("Failed generating audio for scene %s: %s", scene_num, exc)

--- a/src/ai_agentic_workflow/workflows/youtube_wisdom_workflow.py
+++ b/src/ai_agentic_workflow/workflows/youtube_wisdom_workflow.py
@@ -16,6 +16,7 @@ from langchain.tools import Tool
 from src.ai_agentic_workflow.clients.chatgpt_client import DualModelChatClient
 from src.ai_agentic_workflow.clients.gemini_client import DualModelGeminiClient
 from src.ai_agentic_workflow.clients.claude_client import DualModelClaudeClient
+from src.ai_agentic_workflow.utils.media_utils import create_media_files
 
 logger = logging.getLogger(__name__)
 
@@ -224,7 +225,7 @@ class YouTubeWisdomWorkflow:
             ),
             llm=self.o3_mini_client.get_llm(),
             verbose=True,
-            allow_delegation=True,
+            allow_delegation=False,
         )
 
         # 11. Producer (GPT-4) - YouTube Optimization
@@ -284,6 +285,7 @@ class YouTubeWisdomWorkflow:
                 "emotional_journey": "arc from struggle to transformation",
                 "key_takeaway": "memorable closing message"
             }}
+            IMPORTANT: Your entire response must be ONLY the JSON object, without any introductory text, comments, or markdown formatting like ```json.
             """,
             expected_output="Enhanced concept in JSON format",
             agent=self.creative_director,
@@ -366,6 +368,7 @@ class YouTubeWisdomWorkflow:
                 "specific_improvements": ["improvement1", "improvement2"],
                 "strong_points": ["strength1", "strength2"]
             }}
+            IMPORTANT: Your entire response must be ONLY the JSON object, without any introductory text, comments, or markdown formatting like ```json.
             """,
             expected_output="Story review with scores and feedback in JSON format",
             agent=self.story_reviewer,
@@ -402,8 +405,16 @@ class YouTubeWisdomWorkflow:
         tasks.append(story_enhance_task)
 
         # Task 5: Script Writer - Scene Breakdown
+        script_improvement_block = ""
+        if project.script_review and project.attempts > 1:
+            script_improvement_block = (
+                "\n\nPREVIOUS SCRIPT REVIEW FEEDBACK:\n"
+                f"{json.dumps(project.script_review, indent=2)}\n"
+                "Rewrite the script addressing these points."
+            )
+
         script_task = Task(
-            description="""
+            description=f"""
             Transform the enhanced wisdom story into a detailed scene-by-scene script optimized for a 4-5 minute video.
 
             SCRIPT CONVERSION GUIDELINES:
@@ -441,6 +452,8 @@ class YouTubeWisdomWorkflow:
                     }}
                 ]
             }}
+            {script_improvement_block}
+            IMPORTANT: Your entire response must be ONLY the JSON object, without any introductory text, comments, or markdown formatting like ```json.
             """,
             expected_output="Scene breakdown in JSON format",
             agent=self.script_writer,
@@ -477,6 +490,7 @@ class YouTubeWisdomWorkflow:
                 "scene_specific_feedback": {{"scene_X": "feedback"}},
                 "improvement_suggestions": ["suggestion1", "suggestion2"]
             }}
+            IMPORTANT: Your entire response must be ONLY the JSON object, without any introductory text, comments, or markdown formatting like ```json.
             """,
             expected_output="Script review with detailed feedback in JSON format",
             agent=self.script_reviewer,
@@ -502,6 +516,7 @@ class YouTubeWisdomWorkflow:
             Maintain the 4-5 minute total duration while incorporating all improvements.
 
             OUTPUT FORMAT: Same JSON structure as the original script with all enhancements applied.
+            IMPORTANT: Your entire response must be ONLY the JSON object, without any introductory text, comments, or markdown formatting like ```json.
             """,
             expected_output="Enhanced scene breakdown in JSON format",
             agent=self.script_enhancer,
@@ -532,13 +547,15 @@ class YouTubeWisdomWorkflow:
                 "symbolic_elements": ["element1", "element2"],
                 "composition": "camera angle and framing",
                 "mood": "overall feeling",
-                "style_modifiers": ["cinematic", "contemplative", "spiritual"]
+                "style_modifiers": ["cinematic", "contemplative", "spiritual"],
+                "aspect_ratio": "16:9",
             }}
 
             OUTPUT FORMAT as JSON:
             {{
                 "visual_prompts": [array of prompt objects for each scene]
             }}
+            IMPORTANT: Your entire response must be ONLY the JSON object, without any introductory text, comments, or markdown formatting like ```json.
             """,
             expected_output="Visual prompts in JSON format",
             agent=self.visual_director,
@@ -588,6 +605,7 @@ class YouTubeWisdomWorkflow:
             {{
                 "audio_scripts": [array of audio direction objects for each scene]
             }}
+            IMPORTANT: Your entire response must be ONLY the JSON object, without any introductory text, comments, or markdown formatting like ```json.
             """,
             expected_output="Audio scripts in JSON format",
             agent=self.sound_designer,
@@ -624,6 +642,7 @@ class YouTubeWisdomWorkflow:
                 "revision_recommendations": ["specific improvements needed"],
                 "quality_score": 0-100
             }}
+            IMPORTANT: Your entire response must be ONLY the JSON object, without any introductory text, comments, or markdown formatting like ```json.
             """,
             expected_output="Quality validation report in JSON format",
             agent=self.quality_controller,
@@ -635,6 +654,7 @@ class YouTubeWisdomWorkflow:
         youtube_task = Task(
             description="""
             Create optimized YouTube metadata for maximum reach and engagement.
+            Before generating metadata, check the Quality Controller's report. If approval_status is "NEEDS_REVISION", return placeholder metadata and highlight required fixes.
 
             OPTIMIZATION REQUIREMENTS:
             - Title: Transformation promise with wisdom authority (50-70 characters)
@@ -663,6 +683,7 @@ class YouTubeWisdomWorkflow:
                 }},
                 "engagement_strategy": "community interaction plan"
             }}
+            IMPORTANT: Your entire response must be ONLY the JSON object, without any introductory text, comments, or markdown formatting like ```json.
             """,
             expected_output="YouTube optimization package in JSON format",
             agent=self.producer,
@@ -674,6 +695,7 @@ class YouTubeWisdomWorkflow:
 
     STORY_REVIEW_THRESHOLD = 85
     MAX_RETRIES = 3
+    SCRIPT_REVIEW_THRESHOLD = 85
 
     def run(self, initial_idea: str, debug: bool = False) -> VideoProject:
         """Run the complete workflow for wisdom video generation with self-correction.
@@ -754,18 +776,35 @@ class YouTubeWisdomWorkflow:
 
                 if project.quality_report.get("approval_status") == "APPROVED":
                     project.final_approved = True
+                else:
+                    logger.warning(
+                        "Quality control failed with status: %s",
+                        project.quality_report.get("approval_status"),
+                    )
+                    project.youtube_metadata = {}
 
                 score = project.story_review.get("overall_score", 0)
+                script_score = project.script_review.get("overall_score", 0)
                 logger.info("Story review score: %s", score)
-                if score >= self.STORY_REVIEW_THRESHOLD or attempt == self.MAX_RETRIES:
+                logger.info("Script review score: %s", script_score)
+                if (score >= self.STORY_REVIEW_THRESHOLD and script_score >= self.SCRIPT_REVIEW_THRESHOLD) or attempt == self.MAX_RETRIES:
                     break
                 logger.info(
-                    "Score below threshold %s, retrying...",
+                    "Scores below threshold (story %s/<%s>, script %s/<%s>), retrying...",
+                    score,
                     self.STORY_REVIEW_THRESHOLD,
+                    script_score,
+                    self.SCRIPT_REVIEW_THRESHOLD,
                 )
             except Exception as e:
                 logger.error(f"Error processing crew outputs: {e}")
                 break
+
+        if project.visual_prompts and project.enhanced_script:
+            try:
+                create_media_files(project.visual_prompts, project.enhanced_script)
+            except Exception as e:  # pragma: no cover - external calls
+                logger.error("Media generation failed: %s", e)
 
         return project
 


### PR DESCRIPTION
## Summary
- implement helpers to generate images via OpenAI and audio via Gemini TTS
- store media files using scene number prefixes
- invoke media generation at end of YouTube workflow

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684d7926d684832b98db261ff42a870e